### PR TITLE
RMagick only accepts lowercase file extensions. Adding uppercase versions

### DIFF
--- a/lib/sprite_factory/library/rmagick.rb
+++ b/lib/sprite_factory/library/rmagick.rb
@@ -4,7 +4,7 @@ module SpriteFactory
   module Library
     module RMagick
 
-      VALID_EXTENSIONS = [:png, :jpg, :jpeg, :gif]
+      VALID_EXTENSIONS = [:png, :PNG, :jpg, :JPG, :jpeg, :JPEG, :gif, :GIF]
 
       def self.load(files)
         files.map do |filename|


### PR DESCRIPTION
RMagick only accepts lowercase file extensions. Adding uppercase versions of the existing VALID_EXTENSIONS.
