### PR TITLE
Added !important

### DIFF
--- a/lib/sprite_factory/style.rb
+++ b/lib/sprite_factory/style.rb
@@ -51,7 +51,7 @@ module SpriteFactory
         attr = [
           "width: #{image[:cssw]}px",
           "height: #{image[:cssh]}px",
-          "background: #{url} #{-image[:cssx]}px #{-image[:cssy]}px no-repeat"
+          "background: #{url} #{-image[:cssx]}px #{-image[:cssy]}px no-repeat !important"
         ]
         image[:selector] = selector                          # make selector available for (optional) custom rule generators
         image[:style]    = send("#{style_name}_style", attr) # make pure style available for (optional) custom rule generators (see usage of yield inside Runner#style)


### PR DESCRIPTION
In my rake file I'm using SpriteFactory.run!(... :selector => '.' ...) which produces just classes that I can use on any element. 

This change will ensure - where there's more CSS specificity - that nothing else  will override the background.
