### PR TITLE
Add an ImageMagick driver

### DIFF
--- a/lib/sprite_factory.rb
+++ b/lib/sprite_factory.rb
@@ -55,8 +55,9 @@ module SpriteFactory
 
   module Library # abstract module for using various image libraries
 
-    autoload :RMagick,   File.join(LIB, 'sprite_factory/library/rmagick')    # concrete module for using RMagick   (loaded on demand)
-    autoload :ChunkyPng, File.join(LIB, 'sprite_factory/library/chunky_png') # concrete module for using ChunkyPng (ditto)
+    autoload :RMagick,     File.join(LIB, 'sprite_factory/library/rmagick')      # concrete module for using RMagick     (loaded on demand)
+    autoload :ChunkyPng,   File.join(LIB, 'sprite_factory/library/chunky_png')   # concrete module for using ChunkyPng   (ditto)
+    autoload :ImageMagick, File.join(LIB, 'sprite_factory/library/image_magick') # concrete module for using ImageMagick (ditto)
 
     def self.rmagick
       RMagick
@@ -64,6 +65,10 @@ module SpriteFactory
 
     def self.chunkypng
       ChunkyPng
+    end
+    
+    def self.image_magick
+      ImageMagick
     end
 
   end

--- a/lib/sprite_factory/library/image_magick.rb
+++ b/lib/sprite_factory/library/image_magick.rb
@@ -1,0 +1,74 @@
+module SpriteFactory
+  module Library
+    module ImageMagick
+
+      # Represents an error from an underlying ImageMagick call
+      class Error < RuntimeError
+        attr_reader :command
+        attr_reader :args
+        attr_reader :output
+        
+        def initialize(msg, command, args, output)
+          super(msg)
+          @command = command
+          @args = args
+          @output = output
+        end
+      end
+
+      VALID_EXTENSIONS = [:png, :jpg, :jpeg, :gif, :ico]
+
+      def self.load(files)
+        files.map do |filename|
+          path = "#{filename}[0]"   # layer 0
+          output = run("identify", ['-format', '%wx%h', path])
+          
+          width, height = output.chomp.split(/x/).map(&:to_i)
+          {
+            :filename => filename,
+            :path     => path,
+            :width    => width,
+            :height   => height
+          }
+        end
+      end
+
+      def self.create(filename, images, width, height)
+        # we want to invoke:
+        # convert -size #{width}x#{height} xc:none
+        #   #{input} -geometry +#{x}+#{y} -composite
+        # #{output}
+        
+        args = ["-size", "#{width}x#{height}", "xc:none"]
+        images.each do |image|
+          args +=  [image[:path], "-geometry", "+#{image[:x]}+#{image[:y]}", "-composite"]
+        end
+        args << filename
+        
+        run("convert", args)
+        true
+      end
+      
+      protected
+      def self.run(command, args)
+        full_command = [command] + args.map(&:to_s)
+        
+        r, w = IO.pipe
+        pid = Process.spawn(*full_command, {[:out, :err] => w})
+        
+        w.close
+        output = r.read
+        
+        Process.waitpid(pid)
+        success = $?.exitstatus == 0 ? true : false
+        
+        if !success
+          raise Error.new("error running `#{command}` (check $!.args/$!.output for more information)", command, args, output)
+        end
+        
+        output
+      end
+      
+    end # module ImageMagick
+  end # module Library
+end # module SpriteFactory

--- a/test/library_test.rb
+++ b/test/library_test.rb
@@ -5,8 +5,9 @@ class SpriteFactory::LibraryTest < SpriteFactory::TestCase
   #--------------------------------------------------------------------------
 
   LIBRARIES = {
-    :rmagick   => SpriteFactory::Library::RMagick,
-    :chunkypng => SpriteFactory::Library::ChunkyPng
+    :rmagick      => SpriteFactory::Library::RMagick,
+    :chunkypng    => SpriteFactory::Library::ChunkyPng,
+    :image_magick => SpriteFactory::Library::ImageMagick
   }
 
   #--------------------------------------------------------------------------


### PR DESCRIPTION
This output driver invokes `identify` and `convert` directly via Process.spawn, requiring ImageMagick to be installed but requiring no additional gems.
