### PR TITLE
Add padding and margin options to the CLI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can see the results of many of these options by viewing the sample page that
 comes with the gem in `test/images/reference/index.html`.
 
 >> NOTE: only the common options are available via the command line script (to keep it simple). Specifically,
-the advanced `width`, `height`, `padding`, `margin` and `nocss` options are only available via the Ruby interface.
+the advanced `width`, `height`, and `nocss` options are only available via the Ruby interface.
 
 >> NOTE: the `width`, `height` and `padding` options are not particularly useful - you would be better off just
 making your source images have the correct dimensions by editing them appropriately in photoshop (or your editor of choice)

--- a/bin/sf
+++ b/bin/sf
@@ -27,6 +27,8 @@ cssurl_help       = "specify custom string to use for css image urls ( default: 
 output_image_help = "specify output location for generated image ( default: <input folder>.png )"
 output_style_help = "specify output location for generated stylesheet ( default: <input folder>.<style>)"
 pngcrush_help     = "use pngcrush to optimize generated image"
+padding_help      = "add padding to each sprite"
+margin_help       = "add margin to each sprite"
 nocomments_help   = "suppress comments in generated stylesheet"
 
 op.on("--layout       [ORIENTATION]", layout_help)       {|value| options[:layout]       = value }
@@ -37,6 +39,8 @@ op.on("--cssurl       [CSSURL]",      cssurl_help)       {|value| options[:cssur
 op.on("--output-image [PATH]",        output_image_help) {|value| options[:output_image] = value }
 op.on("--output-style [PATH]",        output_style_help) {|value| options[:output_style] = value }
 op.on("--pngcrush",                   pngcrush_help)     {|value| options[:pngcrush]     = value }
+op.on("--padding [PIXELS]",           padding_help)      {|value| options[:padding]      = value.to_i }
+op.on("--margin [PIXELS]",            margin_help)       {|value| options[:margin]       = value.to_i }
 op.on("--nocomments",                 nocomments_help)   {|value| options[:nocomments]   = true  }
 
 begin


### PR DESCRIPTION
This PR adds the margin and padding options to the command line interface. Even though it stated in the docs that they were only available through the Ruby interface because they were not common, I've found them particularly useful in the project my team is working on. And having them there doesn't hurt.
