### PR TITLE
Add -q to pngcrush to suppress it's output.

### DIFF
--- a/lib/sprite_factory/runner.rb
+++ b/lib/sprite_factory/runner.rb
@@ -243,7 +243,7 @@ module SpriteFactory
     def pngcrush(image)
       if SUPPORTS_PNGCRUSH && config[:pngcrush]
         crushed = "#{image}.crushed"
-        `pngcrush -rem alla -reduce -brute #{image} #{crushed}`
+        `pngcrush -q -rem alla -reduce -brute #{image} #{crushed}`
         FileUtils.mv(crushed, image) 
       end
     end


### PR DESCRIPTION
pngcrush generates a lot of output.  This patch adds -q to suppress that.
