### PR TITLE
Use system instead of backticks for pngcrush so file names with spaces a...

### DIFF
--- a/lib/sprite_factory/runner.rb
+++ b/lib/sprite_factory/runner.rb
@@ -243,7 +243,7 @@ module SpriteFactory
     def pngcrush(image)
       if SUPPORTS_PNGCRUSH && config[:pngcrush]
         crushed = "#{image}.crushed"
-        `pngcrush -q -rem alla -reduce -brute #{image} #{crushed}`
+        system('pngcrush', '-q', '-rem alla', '-reduce', '-brute', image, crushed)
         FileUtils.mv(crushed, image) 
       end
     end


### PR DESCRIPTION
...re properly escaped.

If the path the images are contained in contained a space, pngcrush would return an error that it couldn't find the file.

```
$ find foo\ bar
foo bar
foo bar/ph.png
```

```
$ sf foo\ bar --pngcrush --library chunkypng

        Creating a sprite from following images:

        foo bar/ph.png (269x397)

        Output files:
          foo bar.png
          foo bar.css

        Output size:
          269x397

Could not find file: foo
Could not find file: bar.png
Could not find file: foo
Could not find file: bar.png.crushed
No such file or directory - foo bar.png.crushed
```
