### PR TITLE
require `rmagick` instead of `RMagick` (the latter is deprecated)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ source "http://rubygems.org"
 
 group :development do
   gem "chunky_png", "1.3.0"
-  gem "rmagick",    "2.13.2"
+  gem "rmagick",    "2.13.4"
 end

--- a/lib/sprite_factory/library/rmagick.rb
+++ b/lib/sprite_factory/library/rmagick.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require 'rmagick'
 
 module SpriteFactory
   module Library


### PR DESCRIPTION
 - Bump rmagick version to 2.13.4 (oldest version with the
   non-deprecated require