### PR TITLE
Added glob pattern to options hash

### DIFF
--- a/bin/sf
+++ b/bin/sf
@@ -19,6 +19,7 @@ op.on("-v", "--version") do
   exit
 end
 
+glob_pattern_help = "specify glob pattern used to find images ( default: '*' )"
 layout_help       = "specify layout orientation   ( horizontal, vertical, packed )"
 style_help        = "specify stylesheet syntax  ( css, scss, sass )"
 library_help      = "specify image library to use ( rmagic, chunkypng )"
@@ -31,6 +32,7 @@ padding_help      = "add padding to each sprite"
 margin_help       = "add margin to each sprite"
 nocomments_help   = "suppress comments in generated stylesheet"
 
+op.on("--glob-pattern [PATTERN]",     glob_pattern_help) {|value| options[:glob_pattern] = value }
 op.on("--layout       [ORIENTATION]", layout_help)       {|value| options[:layout]       = value }
 op.on("--style        [STYLE]",       style_help)        {|value| options[:style]        = value }
 op.on("--library      [LIBRARY]",     library_help)      {|value| options[:library]      = value }
@@ -51,5 +53,3 @@ rescue Exception => ex
   puts ex.message
   exit
 end
-
-

--- a/lib/sprite_factory.rb
+++ b/lib/sprite_factory.rb
@@ -1,5 +1,5 @@
 module SpriteFactory
-  
+
   #----------------------------------------------------------------------------
 
   VERSION     = "1.6.2"
@@ -19,6 +19,7 @@ module SpriteFactory
   # avoid having to pass them to #run! every single time
   #
   class << self
+    attr_accessor :glob_pattern
     attr_accessor :report
     attr_accessor :style
     attr_accessor :layout
@@ -51,7 +52,7 @@ module SpriteFactory
     end
 
   end
-  
+
   #----------------------------------------------------------------------------
 
   module Library # abstract module for using various image libraries
@@ -67,7 +68,7 @@ module SpriteFactory
     def self.chunkypng
       ChunkyPng
     end
-    
+
     def self.image_magick
       ImageMagick
     end

--- a/lib/sprite_factory/runner.rb
+++ b/lib/sprite_factory/runner.rb
@@ -12,7 +12,7 @@ module SpriteFactory
 
     attr :input
     attr :config
-  
+
     def initialize(input, config = {})
       @input  = input.to_s[-1] == "/" ? input[0...-1] : input # gracefully ignore trailing slash on input directory name
       @config = config
@@ -25,8 +25,9 @@ module SpriteFactory
       @config[:pngcrush]   ||= SpriteFactory.pngcrush
       @config[:nocomments] ||= SpriteFactory.nocomments
       @config[:directory_separator] ||= SpriteFactory.directory_separator || '_'
+      @config[:glob_pattern]        ||= SpriteFactory.glob_pattern        || '*'
     end
-  
+
     #----------------------------------------------------------------------------
 
     def run!(&block)
@@ -76,7 +77,7 @@ module SpriteFactory
     end
 
     #----------------------------------------------------------------------------
-  
+
     private
 
     def selector
@@ -166,7 +167,7 @@ module SpriteFactory
     def image_files
       return [] if input.nil?
       valid_extensions = library::VALID_EXTENSIONS
-      expansions = Array(valid_extensions).map{|ext| File.join(input, "**", "*.#{ext}")}
+      expansions = Array(valid_extensions).map{|ext| File.join(input, "**", "#{config[:glob_pattern]}.#{ext}")}
       SpriteFactory.find_files(*expansions)
     end
 
@@ -249,7 +250,7 @@ module SpriteFactory
       if SUPPORTS_PNGCRUSH && config[:pngcrush]
         crushed = "#{image}.crushed"
         system('pngcrush', '-q', '-rem alla', '-reduce', '-brute', image, crushed)
-        FileUtils.mv(crushed, image) 
+        FileUtils.mv(crushed, image)
       end
     end
 


### PR DESCRIPTION
I'm considering sprite-factory for developing Shopify themes where all assets are located in a single directory. Moving the glob pattern to the options hash allows me to namespace those images that belong in the sprite and target them specifically.